### PR TITLE
support macOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -48,7 +48,14 @@
                     "-lsodium"
                 ]
             },
+            'conditions': [
+                ['OS=="mac"', {
+                    'xcode_settings': {
+                        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+                    }
+                }]
+            ]
         }
-       ]
+    ]
 }
 

--- a/crypto/common.h
+++ b/crypto/common.h
@@ -9,7 +9,28 @@
 #include <assert.h>
 
 #include "sodium.h"
-#include <endian.h>
+
+#ifndef __APPLE__
+    #include <endian.h>
+#else
+    #include <machine/endian.h>
+    #include <libkern/OSByteOrder.h>
+
+    #define htobe16(x) OSSwapHostToBigInt16(x)
+    #define htole16(x) OSSwapHostToLittleInt16(x)
+    #define be16toh(x) OSSwapBigToHostInt16(x)
+    #define le16toh(x) OSSwapLittleToHostInt16(x)
+
+    #define htobe32(x) OSSwapHostToBigInt32(x)
+    #define htole32(x) OSSwapHostToLittleInt32(x)
+    #define be32toh(x) OSSwapBigToHostInt32(x)
+    #define le32toh(x) OSSwapLittleToHostInt32(x)
+
+    #define htobe64(x) OSSwapHostToBigInt64(x)
+    #define htole64(x) OSSwapHostToLittleInt64(x)
+    #define be64toh(x) OSSwapBigToHostInt64(x)
+    #define le64toh(x) OSSwapLittleToHostInt64(x)
+#endif
 
 #if defined(NDEBUG)
 # error "Zcash cannot be compiled without assertions."

--- a/crypto/equihash.cpp
+++ b/crypto/equihash.cpp
@@ -16,7 +16,7 @@
 #include "config/bitcoin-config.h"
 #endif
 
-#include <endian.h>
+#include "crypto/common.h"
 #include "crypto/equihash.h"
 #include <algorithm>
 #include <iostream>

--- a/serialize.h
+++ b/serialize.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_SERIALIZE_H
 #define BITCOIN_SERIALIZE_H
 
-#include <endian.h>
 #include <algorithm>
 #include <assert.h>
 #include <ios>
@@ -22,6 +21,8 @@
 
 #include <boost/array.hpp>
 #include <boost/optional.hpp>
+
+#include "crypto/common.h"
 
 class CScript;
 


### PR DESCRIPTION
`npm install` failed under macOS because different `endian.h` and no c++ `throw`

refs:
https://gist.github.com/yinyin/2027912
https://github.com/nodejs/node-gyp/issues/17